### PR TITLE
Fix ghc-8 errors

### DIFF
--- a/preprocessor.cabal
+++ b/preprocessor.cabal
@@ -34,6 +34,8 @@ library
                      , optparse-generic
                      , process
                      , syb
+  if impl(ghc >= 8.0)
+    build-depends:     template-haskell
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/stack-8.0.1.yaml
+++ b/stack-8.0.1.yaml
@@ -1,0 +1,10 @@
+resolver: nightly-2016-07-19
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
- CPP flag was moved to template-haskell package
- GHC.LogAction now also has a WarnReason argument

Also add a stack.yaml for ghc 8 so you can run:
$ STACK_YAML=stack-8.0.1.yaml
